### PR TITLE
Fix error handling

### DIFF
--- a/src/client/error/request-failed.js
+++ b/src/client/error/request-failed.js
@@ -13,6 +13,7 @@ class RequestFailedError extends Error {
     this.url = url;
     this.response = response;
     this.reason = reason;
+    this.data = response.data;
   }
 }
 

--- a/src/client/error/request-failed.js
+++ b/src/client/error/request-failed.js
@@ -1,7 +1,7 @@
 class RequestFailedError extends Error {
   /**
    * @param {string} url
-   * @param {*} response 
+   * @param {*} response
    */
   constructor(url, response) {
     const { message, reason } = response instanceof Error ? response : response.data;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -7,7 +7,7 @@ const api = require('./api');
 
 class Coingate {
   /**
-   * @param {*} config 
+   * @param {*} config
    */
   constructor(config) {
     this.config = config;
@@ -15,7 +15,7 @@ class Coingate {
 
   /**
    * Injects API methods from config
-   * @param {*} metadata 
+   * @param {*} metadata
    */
   injectApiMethods(metadata) {
     for (let name of Object.keys(metadata)) {
@@ -23,7 +23,7 @@ class Coingate {
         const { method, entity, data, params, transform } = await metadata[name](...args);
 
         let result = await this.request(method, entity, data, params);
-        
+
         if (transform && typeof transform === 'function') {
           result = await transform(result);
         }
@@ -37,9 +37,9 @@ class Coingate {
 
   /**
    * Make a request to API
-   * @param {string} method 
+   * @param {string} method
    * @param {string} entity
-   * @param {*} data 
+   * @param {*} data
    * @param {*} params
    */
   async request(method, entity, data, params) {
@@ -47,7 +47,7 @@ class Coingate {
     const { apiUrl, apiBase } = this.config;
     const { headers } = this;
     const url = new URL(path.join(apiBase, entity), apiUrl).toString();
-    
+
     try {
       response = await axios.request({
         method, headers, data, params, url,
@@ -77,7 +77,7 @@ class Coingate {
   get authHeaders() {
     return { 'Authorization': `Token ${ this.config.token }` };
   }
-  
+
   /**
    * Create Coingate client
    */

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -53,6 +53,9 @@ class Coingate {
         method, headers, data, params, url,
       });
     } catch (error) {
+      if (error.response) {
+        error = error.response;
+      }
       throw new RequestFailedError(url, error);
     }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,8 +4,8 @@ export let Client: Coingate;
 export let Config: ConfigType;
 
 interface ClientType {
-  createOrder(options: CreateOrderOptions): Promise<(Order | ErrorCreateOrder)>;
-  getOrder(orderId: number): Promise<(Order | ErrorGetOrder)>;
+  createOrder(options: CreateOrderOptions): Promise<Order>;
+  getOrder(orderId: number): Promise<Order>;
   listOrders(options?: ListOrderOptions): Promise<ListOrdersReturn>;
   getExchangeRate(from: string, to: string): Promise<number>;
   listExchangeRates(): Promise<ExchangeRatesReturn>;
@@ -42,17 +42,6 @@ interface Order {
   order_id: string;
   payment_url: string;
   token?: string;
-}
-
-interface ErrorCreateOrder {
-  message: string;
-  reason: string;
-  errors: string[];
-}
-
-interface ErrorGetOrder {
-  message: string;
-  reason: string;
 }
 
 interface ListOrderOptions {


### PR DESCRIPTION
API Errors like Order not found, return 4xx errors, this triggers an Error in axios.request, which is mistaken as Error without any response.

In additions are errors not returned as values, but as exception. So the types got updated.

Maybe the error handling could be further improved by seperating Network errors from api errors.